### PR TITLE
Add Jimi search

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,9 @@ jobs:
     - name: Build Jekyll website
       run: |
          bundle exec jekyll build
+      env:
+        JIMI_USERNAME: "${{ secrets.JIMI_USERNAME }}"
+        JIMI_PASSWORD: "${{ secrets.JIMI_PASSWORD }}"
     - name: Deploy GitHub Pages
       uses: JamesIves/github-pages-deploy-action@4.1.4
       with:

--- a/_config.yml
+++ b/_config.yml
@@ -165,7 +165,7 @@ pageview:
 ## => Search
 ##############################
 search:
-  provider: default # "default" (default), false, "google", "custom"
+  provider: jimi # "default" (default), false, "google", "custom"
 
   ## Google Custom Search Engine
   google:

--- a/_includes/scripts/rum.html
+++ b/_includes/scripts/rum.html
@@ -1,0 +1,24 @@
+<script>
+  (function(h,o,u,n,d) {
+    h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
+    d=o.createElement(u);d.async=1;d.src=n
+    n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum-v4.js','DD_RUM')
+  DD_RUM.onReady(function() {
+    DD_RUM.init({
+      clientToken: 'pubcda42e398091be9674a1ef9abd156415',
+      applicationId: '88839061-4ced-42cf-98c7-169c5e8ab6e4',
+      site: 'datadoghq.eu',
+      service: 'jingwen-z.github.io',
+      env: 'prod',
+      // Specify a version number to identify the deployed version of your application in Datadog
+      // version: '1.0.0',
+      sampleRate: 100,
+      allowedTracingOrigins: ["https://search.jimidata.info"],
+      trackInteractions: true,
+      defaultPrivacyLevel: 'mask-user-input'
+    });
+
+    DD_RUM.startSessionReplayRecording();
+  })
+</script>

--- a/_includes/search-providers/jimi/search-data.js
+++ b/_includes/search-providers/jimi/search-data.js
@@ -1,0 +1,14 @@
+window.TEXT_SEARCH_DATA={
+  {%- for _collection in site.collections -%}
+    {%- unless forloop.first -%},{%- endunless -%}
+    '{{ _collection.my_label | default: _collection.label }}':[
+      {%- for _article in _collection.docs -%}
+      {%- unless forloop.first -%},{%- endunless -%}
+      {'title':{{ _article.title | jsonify }},
+      {%- include snippets/prepend-baseurl.html path=_article.url -%}
+      {%- assign _url = __return -%}
+      'url':{{ _url | jsonify }}}
+      {%- endfor -%}
+    ]
+  {%- endfor -%}
+};

--- a/_includes/search-providers/jimi/search.html
+++ b/_includes/search-providers/jimi/search.html
@@ -1,0 +1,18 @@
+<div class="search search--dark">
+  <div class="main">
+    <div class="search__header">{{ _locale_search }}</div>
+    <div class="search-bar">
+      <div class="search-box js-search-box">
+        <div class="search-box__icon-search"><i class="fas fa-search"></i></div>
+        <input type="text" />
+        <div class="search-box__icon-clear js-icon-clear">
+          <a><i class="fas fa-times"></i></a>
+        </div>
+      </div>
+      <button class="button button--theme-dark button--pill search__cancel js-search-toggle">
+        {{ _locale_cancel }}</button>
+    </div>
+    <div class="search-result js-search-result"></div>
+  </div>
+</div>
+<script>{%- include search-providers/jimi/search.js -%}</script>

--- a/_includes/search-providers/jimi/search.js
+++ b/_includes/search-providers/jimi/search.js
@@ -1,0 +1,155 @@
+var SOURCES = window.TEXT_VARIABLES.sources;
+var PAHTS = window.TEXT_VARIABLES.paths;
+window.Lazyload.js([SOURCES.jquery, PAHTS.search_js], function() {
+  var search = (window.search || (window.search = {}));
+  var searchData = window.TEXT_SEARCH_DATA || {};
+
+  function memorize(f) {
+    var cache = {};
+    return function () {
+      var key = Array.prototype.join.call(arguments, ',');
+      if (key in cache) return cache[key];
+      else return cache[key] = f.apply(this, arguments);
+    };
+  }
+
+  // search
+  function searchByQuery(query) {
+    var i, j, key, keys, cur, _title, result = {};
+    keys = Object.keys(searchData);
+    for (i = 0; i < keys.length; i++) {
+      key = keys[i];
+      for (j = 0; j < searchData[key].length; j++) {
+        cur = searchData[key][j], _title = cur.title;
+        if ((result[key] === undefined || result[key] && result[key].length < 4 )
+          && _title.toLowerCase().indexOf(query.toLowerCase()) >= 0) {
+          if (result[key] === undefined) {
+            result[key] = [];
+          }
+          result[key].push(cur);
+        }
+      }
+    }
+    return result;
+  }
+
+  // search
+  function remoteSearchByQuery(query) {
+    console.log(`searching: ${query}`);
+    var i, j, key, keys, cur, _title;
+    const url = 'https://search.jimidata.info/sites/mincong.io/posts/search?' + $.param({
+      q: query
+    });
+    let start = Date.now();
+    $.ajax({
+      'url': url,
+      'success': function(data) {
+        let duration = Date.now() - start;
+        console.log(`received response successfully (${duration} ms)`);
+
+        result = {};
+        keys = Object.keys(data);
+
+        for (i = 0; i < keys.length; i++) {
+          key = keys[i];
+          for (j = 0; j < data[key].length; j++) {
+            cur = data[key][j], _title = cur.title;
+            if ((result[key] === undefined || result[key] && result[key].length < 4 )
+              && _title.toLowerCase().indexOf(query.toLowerCase()) >= 0) {
+              if (result[key] === undefined) {
+                result[key] = [];
+              }
+              result[key].push(cur);
+            }
+          }
+        }
+
+        $('.js-search-result').html(render(data));
+        $resultItems = $('.search-result__item');
+        activeIndex = 0;
+        $resultItems.eq(0).addClass('active');
+      },
+      'error': function(data) {
+        let duration = Date.now() - start;
+        console.error(`received error response (${duration} ms)`);
+        console.error(data);
+      }
+    })
+  }
+
+  var renderHeader = memorize(function(header) {
+    return $('<p class="search-result__header">' + header + '</p>');
+  });
+
+  var renderItem = function(index, title, url) {
+    return $('<li class="search-result__item" data-index="' + index + '"><a class="button" href="' + url + '">' + title + '</a></li>');
+  };
+
+  function render(data) {
+    if (!data) { return null; }
+    var $root = $('<ul></ul>'), i, j, key, keys, cur, itemIndex = 0;
+    keys = Object.keys(data);
+    for (i = 0; i < keys.length; i++) {
+      key = keys[i];
+      $root.append(renderHeader(key));
+      for (j = 0; j < data[key].length; j++) {
+        cur = data[key][j];
+        $root.append(renderItem(itemIndex++, cur.title, cur.url));
+      }
+    }
+    return $root;
+  }
+
+  // search box
+  var $result = $('.js-search-result'), $resultItems;
+  var lastActiveIndex, activeIndex;
+
+  function clear() {
+    $result.html(null);
+    $resultItems = $('.search-result__item'); activeIndex = 0;
+  }
+
+  function onInputNotEmpty(val) {
+    remoteSearchByQuery(val);
+  }
+
+  search.clear = clear;
+  search.onInputNotEmpty = onInputNotEmpty;
+
+  function updateResultItems() {
+    lastActiveIndex >= 0 && $resultItems.eq(lastActiveIndex).removeClass('active');
+    activeIndex >= 0 && $resultItems.eq(activeIndex).addClass('active');
+  }
+
+  function moveActiveIndex(direction) {
+    var itemsCount = $resultItems ? $resultItems.length : 0;
+    if (itemsCount > 1) {
+      lastActiveIndex = activeIndex;
+      if (direction === 'up') {
+        activeIndex = (activeIndex - 1 + itemsCount) % itemsCount;
+      } else if (direction === 'down') {
+        activeIndex = (activeIndex + 1 + itemsCount) % itemsCount;
+      }
+      updateResultItems();
+    }
+  }
+
+  // Char Code: 13  Enter, 37  ⬅, 38  ⬆, 39  ➡, 40  ⬇
+  $(window).on('keyup', function(e) {
+    var modalVisible = search.getModalVisible && search.getModalVisible();
+    if (modalVisible) {
+      if (e.which === 38) {
+        modalVisible && moveActiveIndex('up');
+      } else if (e.which === 40) {
+        modalVisible && moveActiveIndex('down');
+      } else if (e.which === 13) {
+        modalVisible && $resultItems && activeIndex >= 0 && $resultItems.eq(activeIndex).children('a')[0].click();
+      }
+    }
+  });
+
+  $result.on('mouseover', '.search-result__item > a', function() {
+    var itemIndex = $(this).parent().data('index');
+    itemIndex >= 0 && (lastActiveIndex = activeIndex, activeIndex = itemIndex, updateResultItems());
+  });
+});

--- a/_includes/search-providers/jimi/search.js
+++ b/_includes/search-providers/jimi/search.js
@@ -37,7 +37,7 @@ window.Lazyload.js([SOURCES.jquery, PAHTS.search_js], function() {
   function remoteSearchByQuery(query) {
     console.log(`searching: ${query}`);
     var i, j, key, keys, cur, _title;
-    const url = 'https://search.jimidata.info/sites/mincong.io/posts/search?' + $.param({
+    const url = 'https://search.jimidata.info/sites/jingwen-z.github.io/posts/search?' + $.param({
       q: query
     });
     let start = Date.now();

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -15,6 +15,8 @@
   {%- include search-providers/default/search.html -%}
 {%- elsif site.search.provider == 'google' -%}
   {%- include search-providers/google-custom-search-engine/search.html -%}
+{%- elsif site.search.provider == 'jimi' -%}
+  {%- include search-providers/jimi/search.html -%}
 {%- elsif site.search.provider == 'custom' -%}
   {%- include search-providers/custom/search.html -%}
 {%- endif -%}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -13,6 +13,7 @@ layout: none
       {%- include scripts/lib/lazyload.js -%}
     </script>
     {%- include scripts/variables.html -%}
+    {%- include scripts/rum.html -%}
   </head>
   <body>
     <div class="root" data-is-touch="false">

--- a/_plugins/hooks/site/post_write/blogsearch.rb
+++ b/_plugins/hooks/site/post_write/blogsearch.rb
@@ -1,0 +1,48 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+Jekyll::Hooks.register :site, :post_write do |site|
+    jekyll_env = ENV["JEKYLL_ENV"]
+    jimi_enabled_env = ENV["JIMI_ENABLED"]
+    jimi_enabled = jekyll_env == "prod" || jimi_enabled_env == "true"
+
+    if !jimi_enabled
+        Jekyll.logger.info "Jimi search is disabled"
+        next
+    end
+
+    Jekyll.logger.info "Updating blog posts to BlogSearch..."
+    username = ENV["JIMI_USERNAME"]
+    password = ENV["JIMI_PASSWORD"]
+
+    site_info = Net::HTTP.get URI('https://search.jimidata.info')
+    Jekyll.logger.info site_info
+
+    # See more variables in https://jekyllrb.com/docs/variables/
+    site.posts.docs.each { |post|
+        url = post.url
+        title = post.data["title"]
+        content = post.content
+        Jekyll.logger.info "Indexing post: " + title + " (" + post.id + ")"
+
+        pos = post.id.rindex('/') + 1
+        postId = post.id[pos..-1]  # hack: remove prefix
+        uri = URI.parse('https://search.jimidata.info/sites/jingwen-z.github.io/posts/' + postId)
+        Jekyll.logger.info uri
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+
+        headers = {"Content-Type": "application/json"}
+        body = {"title" => title, "url" => url, "content" => content}.to_json
+
+        request = Net::HTTP::Put.new(uri.request_uri, headers)
+        request.basic_auth username, password
+        request.body = body
+
+        response = http.request(request)
+
+        Jekyll.logger.info response.code + " " + response.body
+    }
+end

--- a/docker-serve.sh
+++ b/docker-serve.sh
@@ -5,7 +5,10 @@
 export JEKYLL_VERSION=3.8
 docker run --rm \
   -p 4000:4000 \
+  --env "JIMI_USERNAME=${JIMI_USERNAME}" \
+  --env "JIMI_PASSWORD=${JIMI_PASSWORD}" \
+  --name jekyll \
   --volume="$PWD:/srv/jekyll" \
   --volume="$PWD/vendor/bundle:/usr/local/bundle" \
-  -it jekyll/jekyll:$JEKYLL_VERSION \
+  -it "jekyll/jekyll:${JEKYLL_VERSION}" \
   jekyll serve


### PR DESCRIPTION
## Description

Add new Jimi Search for your blog to provide a better search experience using Elasticsearch. See <https://mincong.io/en/series/blogsearch/>

## Tasks

- [ ] Add new secrets in the project

## Testing

I tested locally, it works well. Blog posts are indexed correctly and searchable from Jimi:

```
➜  ~ curl https://search.jimidata.info/sites/jingwen-z.github.io/posts/search\?q\=python | jq ".posts[].title"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 46826    0 46826    0     0  24736      0 --:--:--  0:00:01 --:--:-- 24723
"Creating a python package for a python job"
"Python: while loop"
"Python: for loop"
"Array manipulation - R vs Python"
"Data structures - R vs Python"
"Python: Connection to Teradata Database"
"Automate python jobs by GitLab CI"
"How to send E-mails with Python?"
"How to create a virtual environment by Python?"
"How to install python module fiona on Windows OS ?"
```